### PR TITLE
Fix iam module merge conflict

### DIFF
--- a/infrastructure/modules/iam/main.tf
+++ b/infrastructure/modules/iam/main.tf
@@ -1,25 +1,3 @@
-<<<<<<< Updated upstream
-resource "aws_iam_role" "this" {
-  name                 = var.role_name
-  assume_role_policy   = var.assume_role_policy == "" ? data.aws_iam_policy_document.this.json : var.assume_role_policy
-  max_session_duration = var.max_session_duration
-  path                 = var.path
-  tags                 = var.tags
-}
-
-resource "aws_iam_role_policy" "this" {
-  count  = var.inline_policy == "" ? 0 : 1
-  name   = "${aws_iam_role.this.name}_inline_policy"
-  role   = aws_iam_role.this.name
-  policy = var.inline_policy
-}
-
-resource "aws_iam_role_policy_attachment" "this" {
-  count      = length(var.policy_arns)
-  role       = aws_iam_role.this.name
-  policy_arn = var.policy_arns[count.index]
-}
-=======
 resource "aws_iam_role" "eks_cluster" {
   name = "${var.cluster_name}-eks-cluster-role"
 
@@ -134,4 +112,3 @@ resource "aws_iam_role_policy_attachment" "irsa_policy_attachment" {
 }
 
 data "aws_region" "current" {}
->>>>>>> Stashed changes


### PR DESCRIPTION
## Summary
- remove unresolved merge conflict markers from `modules/iam/main.tf`
- keep the EKS IAM role definitions

## Testing
- `terraform fmt infrastructure/modules/iam/main.tf`


------
https://chatgpt.com/codex/tasks/task_e_687aad6a6fa8832f95410474db3f3892