### PR TITLE
Fix import path for tests

### DIFF
--- a/hello-basit-comet/tests/test_hello_basit.py
+++ b/hello-basit-comet/tests/test_hello_basit.py
@@ -1,7 +1,9 @@
 import pytest
 import os, sys
 
-sys.path.append(os.path.abspath("./src"))  # Adjust path to include src 
+sys.path.append(
+    os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+)  # Adjust path to include project root relative to this file
 
 @pytest.fixture
 def client():


### PR DESCRIPTION
## Summary
- add package `__init__` under `src`
- update test path logic to point to project root for `src` imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aad68193c832fb565a0dfd3b5be25