### PR TITLE
Fix Terraform apply plan file

### DIFF
--- a/.github/workflows/tf_apply.yaml
+++ b/.github/workflows/tf_apply.yaml
@@ -42,14 +42,18 @@ jobs:
 
       - name: Terraform Plan
         id: plan
-        run: terraform plan -no-color > plan.txt
+        run: |
+          terraform plan -no-color -out=tfplan
+          terraform show -no-color tfplan > plan.txt
         working-directory: infrastructure/app-hello-basit-comet
 
       - name: Upload Plan Output
         uses: actions/upload-artifact@v4
         with:
           name: tfplan
-          path: infrastructure/app-hello-basit-comet/plan.txt
+          path: |
+            infrastructure/app-hello-basit-comet/tfplan
+            infrastructure/app-hello-basit-comet/plan.txt
 
   apply-with-approval:
     name: Terraform Apply (Requires Manual Approval)
@@ -85,5 +89,5 @@ jobs:
         working-directory: infrastructure/app-hello-basit-comet
 
       - name: Terraform Apply
-        run: terraform apply -auto-approve plan.txt
+        run: terraform apply -auto-approve tfplan
         working-directory: infrastructure/app-hello-basit-comet

--- a/.github/workflows/tf_plan.yaml
+++ b/.github/workflows/tf_plan.yaml
@@ -37,7 +37,9 @@ jobs:
 
       - name: Terraform Plan
         id: plan
-        run: terraform plan -no-color | tee plan.txt
+        run: |
+          terraform plan -no-color -out=tfplan
+          terraform show -no-color tfplan > plan.txt
 
       - name: Post Plan to PR
         uses: marocchino/sticky-pull-request-comment@v2


### PR DESCRIPTION
## Summary
- correct terraform plan/apply workflows to use a binary plan file

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ab7640e84832f99c1eadf442cb1f0