### PR TITLE
Enable CloudWatch logs for EKS

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -28,5 +28,22 @@ This repository contains infrastructure-as-code for deploying resources in AWS, 
           
           In rare cases where a single, small resource is required, 
           we may directly leverage official AWS Terraform modules.
-          Direct resource creation without modules should be considered 
-          a last resort to maintain consistency and reduce drift.
+Direct resource creation without modules should be considered
+  a last resort to maintain consistency and reduce drift.
+
+## Enabling CloudWatch Logs for EKS
+
+The EKS module supports automatic creation of a CloudWatch log group. By
+default it is disabled. To enable logging edit the application workspace
+(`app-hello-basit-comet/main.tf`) and set `create_cloudwatch_log_group` to
+`true`.
+
+If a log group already exists from a previous deployment you may need to
+manually delete it before running `terraform apply` again:
+
+```bash
+aws logs delete-log-group --log-group-name /aws/eks/comet-eks/cluster
+```
+
+After removal, re-run Terraform to recreate the log group and enable control
+plane logging.

--- a/infrastructure/app-hello-basit-comet/main.tf
+++ b/infrastructure/app-hello-basit-comet/main.tf
@@ -1,13 +1,18 @@
 module "comet_eks" {
   source = "../modules/eks"
 
-  name                        = "comet-eks"
-  vpc_id                      = data.aws_vpc.comet_vpc.id
-  subnet_ids                  = data.aws_subnets.comet_subnets.ids
-  control_plane_subnet_ids    = data.aws_subnets.comet_control_plane_subnets.ids
-  cluster_version             = "1.32"
-  node_group_role_arn         = "arn:aws:iam::690893780650:role/aws-service-role/support.amazonaws.com/AWSServiceRoleForSupport"
-  create_cloudwatch_log_group = false
+  name                     = "comet-eks"
+  vpc_id                   = data.aws_vpc.comet_vpc.id
+  subnet_ids               = data.aws_subnets.comet_subnets.ids
+  control_plane_subnet_ids = data.aws_subnets.comet_control_plane_subnets.ids
+  cluster_version          = "1.32"
+  node_group_role_arn      = "arn:aws:iam::690893780650:role/aws-service-role/support.amazonaws.com/AWSServiceRoleForSupport"
+  # Enable creation of the EKS log group in CloudWatch so control plane logs are
+  # automatically stored.  If an old log group exists from a previous run you
+  # can remove it via the AWS console or using the AWS CLI
+  #   aws logs delete-log-group --log-group-name /aws/eks/comet-eks/cluster
+  # before applying this configuration.
+  create_cloudwatch_log_group = true
   #eks_managed_node_group_defaults = ["t3.medium"]
 
   eks_managed_node_groups = {


### PR DESCRIPTION
## Summary
- enable creation of CloudWatch log group for the EKS cluster
- document how to toggle log group creation and delete existing log groups

## Testing
- `terraform fmt -check infrastructure/app-hello-basit-comet/main.tf`
- `terraform init -backend=false`
- `terraform validate`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_687ad7af2444832f8e1a1199e46c2c18